### PR TITLE
fix "No module named 'dateutil'" error in case of using SQL_SCRIPT_S3…

### DIFF
--- a/serverless-v2/configurations/performance_test_bootstrap.sh
+++ b/serverless-v2/configurations/performance_test_bootstrap.sh
@@ -9,8 +9,8 @@
 
 set -eu
 
-yum install -y awscli python3
-pip3 install boto3 psycopg2-binary pandas sqlalchemy
+yum install -y python3 python3-pip
+pip3 install --ignore-installed boto3 psycopg2-binary pandas sqlalchemy
 
 aws s3 cp "$PYTHON_SCRIPT" ./script.py
 


### PR DESCRIPTION

*Description of changes:*
Fix "No module named 'dateutil'" error occuring with awscli after installing boto3 package in bootstrap script.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
